### PR TITLE
Adding ingress controller, reducing node groups to 1, using only private subnets

### DIFF
--- a/.github/workflows/eks-tf.yml
+++ b/.github/workflows/eks-tf.yml
@@ -51,28 +51,27 @@ jobs:
         run: terraform validate
 
   # Job for manual invocation (plan, apply, or destroy)
-  manual:
+  eks-cluster-deployment:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    outputs:
+      cluster-outputs: ${{ steps.get-outputs.outputs.outputs }}
     steps:
-      # Step 1: Checkout the repository
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Step 2: Setup Terraform CLI
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.5.0
           cli_config_credentials_token: ${{ secrets.HCP_API_TOKEN }}
 
-      # Step 3: Initialize Terraform
-      - name: Terraform Init
+      - name: Initialize Terraform
         working-directory: ./eks-cluster
         run: terraform init
 
-      # Step 4: Run Terraform Action
       - name: Run Terraform Action
+        id: deploy-cluster
         working-directory: ./eks-cluster
         env:
           TF_CLI_ARGS_plan: "-input=false -var-file=variables.tfvars"
@@ -94,3 +93,55 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Capture Terraform Outputs
+        id: get-outputs
+        working-directory: ./eks-cluster
+        run: terraform output -json > outputs.json
+
+  # Job to deploy ingress after successful cluster deployment
+  deploy-ingress:
+    needs: eks-cluster-deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Parse Terraform Outputs
+        id: parse-outputs
+        run: |
+          echo "Retrieving Terraform outputs"
+          echo "CLUSTER_ENDPOINT=$(jq -r '.cluster_endpoint.value' < ./eks-cluster/outputs.json)" >> $GITHUB_ENV
+          echo "CLUSTER_SECURITY_GROUP_ID=$(jq -r '.cluster_security_group_id.value' < ./eks-cluster/outputs.json)" >> $GITHUB_ENV
+          echo "REGION=$(jq -r '.region.value' < ./eks-cluster/outputs.json)" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=$(jq -r '.cluster_name.value' < ./eks-cluster/outputs.json)" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      # Verify AWS CLI
+      - name: Verify AWS CLI
+        run: aws sts get-caller-identity
+
+      - name: Configure kubectl
+        run: |
+          aws eks --region $REGION update-kubeconfig --name $CLUSTER_NAME
+
+      - name: Install AWS Load Balancer Controller
+        run: |
+          helm repo add eks https://aws.github.io/eks-charts
+          helm repo update
+          helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+            -n kube-system \
+            --set clusterName=$CLUSTER_NAME \
+            --set serviceAccount.create=false \
+            --set serviceAccount.name=aws-load-balancer-controller \
+            --set region=$REGION \
+            --set vpcId=$CLUSTER_SECURITY_GROUP_ID \
+            --set ingressClass=alb
+
+      - name: Deploy Ingress Resources
+        run: kubectl apply -f ingress.yaml

--- a/eks-cluster/ingress.yml
+++ b/eks-cluster/ingress.yml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: null-service
+                port:
+                  number: 80

--- a/eks-cluster/main.tf
+++ b/eks-cluster/main.tf
@@ -1,12 +1,7 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 provider "aws" {
   region = var.region
 }
 
-# Filter out local zones, which are not currently supported 
-# with managed node groups
 data "aws_availability_zones" "available" {
   filter {
     name   = "opt-in-status"
@@ -23,6 +18,7 @@ resource "random_string" "suffix" {
   special = false
 }
 
+# VPC with private subnets only
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.8.1"
@@ -33,15 +29,10 @@ module "vpc" {
   azs  = slice(data.aws_availability_zones.available.names, 0, 3)
 
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
 
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true
-
-  public_subnet_tags = {
-    "kubernetes.io/role/elb" = 1
-  }
 
   private_subnet_tags = {
     "kubernetes.io/role/internal-elb" = 1
@@ -55,59 +46,40 @@ module "eks" {
   cluster_name    = local.cluster_name
   cluster_version = "1.30"
 
-  cluster_endpoint_public_access           = true
-  enable_cluster_creator_admin_permissions = true
+  cluster_endpoint_public_access  = false
+  cluster_endpoint_private_access = true
 
-  cluster_addons = {
-    aws-ebs-csi-driver = {
-      service_account_role_arn = module.irsa-ebs-csi.iam_role_arn
-    }
-  }
+  enable_cluster_creator_admin_permissions = true
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
   eks_managed_node_group_defaults = {
     ami_type = "AL2_x86_64"
-
   }
 
+  # Single node group with private subnets only
   eks_managed_node_groups = {
-    one = {
-      name = "node-group-1"
-
+    private-group = {
+      name           = "private-node-group"
       instance_types = ["t3.small"]
+      subnet_ids     = module.vpc.private_subnets
 
       min_size     = 1
       max_size     = 3
       desired_size = 2
     }
-
-    two = {
-      name = "node-group-2"
-
-      instance_types = ["t3.small"]
-
-      min_size     = 1
-      max_size     = 2
-      desired_size = 1
-    }
   }
 }
 
-
-# https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons/ 
-data "aws_iam_policy" "ebs_csi_policy" {
-  arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-}
-
-module "irsa-ebs-csi" {
+# IAM Role for AWS Load Balancer Controller
+module "irsa_lb_controller" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version = "5.39.0"
 
   create_role                   = true
-  role_name                     = "AmazonEKSTFEBSCSIRole-${module.eks.cluster_name}"
+  role_name                     = "${local.cluster_name}-lb-controller"
   provider_url                  = module.eks.oidc_provider
-  role_policy_arns              = [data.aws_iam_policy.ebs_csi_policy.arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+  role_policy_arns              = ["arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:aws-load-balancer-controller"]
 }


### PR DESCRIPTION
This PR adds

- Naming convention cleanup across eks github action
- Helm definition and corresponding github action job for deploying cluster ingress
- Reduce node groups to 1, using only private subnets 